### PR TITLE
Support AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE environment variables

### DIFF
--- a/aws/credentials.go
+++ b/aws/credentials.go
@@ -4,11 +4,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"gopkg.in/ini.v1"
+	"os"
 )
 
 // SaveCredentials saves credentials to AWS credentials file.
 func SaveCredentials(profileName string, credentials sts.Credentials) error {
-	file := defaults.SharedCredentialsFilename()
+	file := getCredentialsFilename()
 	c, err := ini.LooseLoad(file)
 	if err != nil {
 		return err
@@ -21,4 +22,13 @@ func SaveCredentials(profileName string, credentials sts.Credentials) error {
 	s.Key("aws_session_expiration").SetValue(credentials.Expiration.String())
 
 	return c.SaveTo(file)
+}
+
+func getCredentialsFilename() string {
+	// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+	file := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if len(file) == 0 {
+		file = defaults.SharedCredentialsFilename()
+	}
+	return file
 }

--- a/config/config.go
+++ b/config/config.go
@@ -84,7 +84,7 @@ func Save(cfg Config, profile string) error {
 	section.Key(defaultSessionDurationHoursKeyName).SetValue(strconv.Itoa(cfg.DefaultSessionDurationHours))
 	section.Key(chromeUserDataDirKeyName).SetValue(cfg.ChromeUserDataDir)
 
-	file := defaults.SharedConfigFilename()
+	file := getConfigFilename()
 	dir := filepath.Dir(file)
 	err = os.MkdirAll(dir, os.FileMode(0755))
 	if err != nil {
@@ -94,8 +94,17 @@ func Save(cfg Config, profile string) error {
 	return f.SaveTo(file)
 }
 
+func getConfigFilename() string {
+	// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+	file := os.Getenv("AWS_CONFIG_FILE")
+	if len(file) == 0 {
+		file = defaults.SharedConfigFilename()
+	}
+	return file
+}
+
 func loadConfigFile() (*ini.File, error) {
-	file := defaults.SharedConfigFilename()
+	file := getConfigFilename()
 	return ini.LooseLoad(file)
 }
 


### PR DESCRIPTION
Fix #72