### PR TITLE
Add roleName option

### DIFF
--- a/aws/saml.go
+++ b/aws/saml.go
@@ -103,7 +103,7 @@ func ParseSAMLResponse(base64Response string) (*SAMLResponse, error) {
 }
 
 // ExtractRoleArnAndPrincipalArn extracts role ARN and principal ARN from SAML response
-func ExtractRoleArnAndPrincipalArn(samlResponse SAMLResponse) (string, string, error) {
+func ExtractRoleArnAndPrincipalArn(samlResponse SAMLResponse, roleName string) (string, string, error) {
 	for _, attr := range samlResponse.Assertion.AttributeStatement.Attributes {
 		if attr.Name != roleAttributeName {
 			continue
@@ -113,6 +113,9 @@ func ExtractRoleArnAndPrincipalArn(samlResponse SAMLResponse) (string, string, e
 			s := strings.Split(v.Value, ",")
 			roleArn := s[0]
 			principalArn := s[1]
+			if roleName != "" && strings.Split(roleArn, "/")[1] != roleName {
+				continue
+			}
 			return roleArn, principalArn, nil
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ func Execute() {
 
 func newRootCmd() *cobra.Command {
 	var configure bool
+	var roleName string
 	var profile string
 	var showVersion bool
 
@@ -82,7 +83,7 @@ func newRootCmd() *cobra.Command {
 				return err
 			}
 
-			roleArn, principalArn, err := aws.ExtractRoleArnAndPrincipalArn(*response)
+			roleArn, principalArn, err := aws.ExtractRoleArnAndPrincipalArn(*response, roleName)
 			if err != nil {
 				return err
 			}
@@ -102,6 +103,7 @@ func newRootCmd() *cobra.Command {
 	}
 	cmd.PersistentFlags().BoolVarP(&configure, "configure", "c", false, "configure initial settings")
 	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "default", "AWS profile")
+	cmd.PersistentFlags().StringVarP(&roleName, "role", "r", "", "AWS IAM role name")
 	cmd.PersistentFlags().BoolVarP(&showVersion, "version", "v", false, "Show version")
 
 	return cmd


### PR DESCRIPTION
assam is great tools. But this tool cannot be used in my environment.

I have two IAM roles as below.

- TestRole1
- TestRole2

I want to use TestRole2, but this tool uses TestRole1.

I can choose the role I want to use.

```
$ assam --role TestRole2
```
