### PR TITLE
ci: Fix the filter patterns that triggered a workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - '**'
     tags-ignore:
-      - '*'
+      - '**'
 
 jobs:
   static-analysis:


### PR DESCRIPTION
A workflow was no longer triggered when the branch name contained "/".