### PR TITLE
ci: Update goreleaser to v0.155.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             ${{ env.cache-version }}-${{ runner.os }}-go-
       - uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.149.0
+          version: v0.155.0
           install-only: true
       - name: Package binaries
         run: make package

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ changelog:
     - Merge pull request
     - Merge branch
 brews:
-  - github:
+  - tap:
       owner: cybozu
       name: homebrew-assam
     description: "Get a credential by AssumeRoleWithSAML for AWS CLI and SDK"


### PR DESCRIPTION
Support for the deleted "brews.github".

https://github.com/goreleaser/goreleaser/commit/11e3afe1c8d1009e085b9af2455f51e75c7c76bc
https://goreleaser.com/deprecations/#brewsgithub