### PR TITLE
ci: add trigger for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
       - '**'
     tags-ignore:
       - '**'
+  pull_request:
+    branches-ignore:
+      - 'renovate/**'
 
 env:
   cache-version: 1


### PR DESCRIPTION
The current configuration does not execute CI Workflow on pull requests from fork repository (ex: #176 ). The above problem can be avoided by adding pull_request to the CI Workflow trigger.

cons: 
The same job will be executed by both push and pull_request. Currently, only the `renovate/**` branch is disabled because Renovate sends a lot of pull requests.