### PR TITLE
fix: replace golint with revive for golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.15.7
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.30.0
+          version: v1.42.1
   go-mod-tidy:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@
 
 linters:
   enable:
-    - golint
+    - revive
     - gofmt
     - govet
   fast: true


### PR DESCRIPTION
because golint is deprecated

x/lint: freeze and deprecate · Issue #38968 · golang/go
https://github.com/golang/go/issues/38968

### Note
Updating the golangci-lint version used in the golangci-lint-action workflow since revive is supported since golangci-lint [v1.37.0](https://github.com/golangci/golangci-lint/releases/tag/v1.37.0).