### PR TITLE
chore: Update goreleaser to v0.183.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             ${{ env.cache-version }}-${{ runner.os }}-go-
       - uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.155.0
+          version: v0.183.0
           install-only: true
       - name: Package binaries
         run: make package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             ${{ env.cache-version }}-${{ runner.os }}-go-
       - uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.149.0
+          version: v0.183.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.MACHINE_ACCOUNT_PAT }}


### PR DESCRIPTION
Because deprecated `bottle :unneeded` is removed.

goreleaser/goreleaser#2591