### PR TITLE
chore: fix renovate settings for golangci-lint

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,7 +24,7 @@
       fileMatch: ["^.tool-versions$"],
       matchStrings: ["golangci-lint (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
       datasourceTemplate: "github-releases",
-      depNameTemplate: "tool-versions/golangci-lint",
+      depNameTemplate: "golangci/golangci-lint",
       extractVersionTemplate: "^v(?<version>.*)$"
     }
   ],
@@ -42,7 +42,7 @@
     {
       groupName: "golangci-lint",
       matchManagers: ["regex"],
-      matchPackageNames: ["tool-versions/golangci-lint"]
+      matchPackageNames: ["golangci/golangci-lint"]
     }
   ]
 }


### PR DESCRIPTION
Fix `depNameTemplate` to follow the format(`<owner>/<repository>`) required by github-releases.

Because the dependency dashboard shows an error.

> ⚠ Dependency Lookup Warnings ⚠
Renovate failed to look up the following dependencies: Failed to look up github-releases dependency tool-versions/golangci-lint.
Files affected: .tool-versions

ref: #223 