### PR TITLE
chore: add workflow for dry-run Renovate

### DIFF
--- a/.github/workflows/dry-run-renovate.yml
+++ b/.github/workflows/dry-run-renovate.yml
@@ -1,0 +1,23 @@
+name: Dry-run Renovate
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - renovate.json5
+      - .github/workflows/dry-run-renovate.yml
+
+permissions:
+  contents: read
+
+jobs:
+  renovate-dry-run:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cybozu/renovate-dry-run-action@v1
+        with:
+          config-file: renovate.json5


### PR DESCRIPTION
Add a workflow to dry-run renovate when renovate.json5 is changed. This makes it easier to check when renovate.json5 changes.

The result is output as a workflow summary.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/20027695/225570084-3a870c19-ccc9-4518-8f50-936be8317334.png">

https://github.com/cybozu/assam/actions/runs/4435338866/attempts/1#summary-12044905085