### PR TITLE
chore: change Renovate check to after 3am on the first day of the month

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,7 @@
     ":timezone(Asia/Tokyo)",
     ":enableVulnerabilityAlertsWithLabel(security)", // Raise PR when vulnerability alerts are detected with label security.
     ":semanticCommitTypeAll(chore)", // If semantic commits detected, use semantic commit type chore for all
-    "schedule:monthly"
+    "schedule:[after 3am on the first day of the month]" // Monthly(before 3am on the first day of the month) is unstable.
   ],
   dependencyDashboard: true,
   dependencyDashboardLabels: ["renovate"],


### PR DESCRIPTION
Preset's Monthly(before 3am on the first day of the month) is unstable. 
So I changed the settings to avoid that.