### PR TITLE
Remove actions/cache and use cache functionality in actions/setup-go

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -13,12 +13,4 @@ runs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ steps.tool-versions.outputs.golang }}
-
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: v2-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          v2-${{ runner.os }}-go-
+        cache: true


### PR DESCRIPTION
## 🏁 Outline

Since the caching feature is implemented in the GitHub actions add-on actions/setup-go, we will stop using actions/cache and use the caching feature of setup-go.

## 🔗 References

- setup-go cache : https://github.com/actions/setup-go/blob/a3d889c34c5d4e071b33595c5fe8edfcaaad8260/action.yml#L15-L17
	doc: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs

## 📝 Description

- Implemented according to the GitHub Actions section on building and caching test documents in Go
	- https://docs.github.com/ja/actions/automating-builds-and-tests/building-and-testing-go#caching-dependencies


## ✅ Test

- Check SSO login with local build version of assam
- Check the logs that setup-go cache feature is used in GitHub Actions execution
