### PR TITLE
update: use go1.20.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-goreleaser 1.15.2
-golang 1.19.5
-golangci-lint 1.50.1
+goreleaser 1.16.1
+golang 1.20.2
+golangci-lint 1.51.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cybozu/assam
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.191


### PR DESCRIPTION
- ## 🏁 Outline

use go 1.20.2

## 🔗 References

- [security] Go 1.20.1 and Go 1.19.6 are released
	- https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E

## 📝 Description

Explicitly version up to go 1.20.2 for security support that came in go 1.20.1.

## ✅ Test

- Check SSO login with local build version of assam
