### PR TITLE
Update golangci-lint 1.52.2 and refactor

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 goreleaser 1.16.1
 golang 1.20.2
-golangci-lint 1.51.2
+golangci-lint 1.52.2

--- a/idp/azure.go
+++ b/idp/azure.go
@@ -34,7 +34,7 @@ func NewAzure(samlRequest string, tenantID string) Azure {
 
 // Authenticate sends SAML request to Azure and fetches SAML response
 func (a *Azure) Authenticate(ctx context.Context, userDataDir string) (string, error) {
-	ctx, cancel := a.setupContext(ctx, userDataDir)
+	ctx, cancel := a.setupContext(userDataDir)
 	defer cancel()
 
 	// Need network.Enable() to handle network events.
@@ -64,7 +64,7 @@ func (a *Azure) Authenticate(ctx context.Context, userDataDir string) (string, e
 	return response, nil
 }
 
-func (a *Azure) setupContext(ctx context.Context, userDataDir string) (context.Context, context.CancelFunc) {
+func (a *Azure) setupContext(userDataDir string) (context.Context, context.CancelFunc) {
 	// Need to expand environment variables because chromedp does not expand.
 	expandedDir := os.ExpandEnv(userDataDir)
 


### PR DESCRIPTION
- delete not use argument (ctx)
- Fixed golangci-lint update failure due to renovate
  - https://github.com/cybozu/assam/actions/runs/4520630144/jobs/8303360094?pr=244
