### PR TITLE
Build for macOS with ubuntu runner, support 64-bit ARM architecture on Windows and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
         run: npx --package renovate renovate-config-validator
   package:
     needs: [static-analysis, go-mod-tidy, test]
-    # Run the build on macOS, because only the macOS version is built with CGO enabled.
-    # See https://github.com/golang/go/issues/12524
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,7 @@ on:
 
 jobs:
   release:
-    # Run the build on macOS, because only the macOS version is built with CGO enabled.
-    # See https://github.com/golang/go/issues/12524
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,14 +9,6 @@ builds:
   goos:
     - linux
     - windows
-  goarch:
-    - amd64
-  ldflags:
-    - "-s -w -X \"github.com/cybozu/assam/cmd.version={{.Version}}\" -X \"github.com/cybozu/assam/cmd.commit={{.ShortCommit}}\" -X \"github.com/cybozu/assam/cmd.date={{.Date}}\""
-- id: assam-darwin
-  env:
-    - CGO_ENABLED=1
-  goos:
     - darwin
   goarch:
     - amd64


### PR DESCRIPTION
## 📝 Description
	
###  Build for macOS with ubuntu runner

When cross-compiling for macOS, DNS resolution was handled improperly. This has been fixed by golang in version 1.20. Build on Ubuntu runner now that the problem is fixed.

#### 🔗 References
- https://danp.net/posts/macos-dns-change-in-go-1-20/
- https://github.com/golang/go/issues/12524
- https://go-review.googlesource.com/c/go/+/446178

### Support 64-bit ARM architecture
- Windows
- Linux

## ✅ Test

- Run on macOS
    - [x] ARM64
    - [x] AMD64
- [x] Run on Windows; ARM64
- [x] Run on Linux; ARM64